### PR TITLE
feat(store): enable deep comparison of objects in diffs

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import {
   extent,
 } from 'd3';
 import fromPairs from 'lodash/fromPairs';
+import isEqual from 'lodash/isEqual';
 import isValidDate from 'date-fns/isValid';
 import parseDate from 'date-fns/parse';
 
@@ -185,7 +186,9 @@ export const createGridStore = () =>
                     newD[columnName].toString()
                   : // @ts-ignore
                     newD[columnName];
-              return oldValue !== newValue;
+              return type === 'object'
+                ? !isEqual(oldValue, newValue)
+                : oldValue !== newValue;
             });
             if (modifiedFields.length) {
               return {
@@ -483,6 +486,10 @@ function generateSchema(data: any[]) {
             ? 'array'
             : 'short-array',
         ];
+      }
+      const isObject = typeof value === 'object';
+      if (isObject) {
+        return [metric, 'object'];
       }
       const isFiniteNumber = Number.isFinite(+value);
       if (isFiniteNumber) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -495,9 +495,7 @@ function generateSchema(data: any[]) {
       if (isFiniteNumber) {
         return [
           metric,
-          metric.toLowerCase().trim() === 'year'
-            ? 'year'
-            : 'number',
+          metric.toLowerCase().trim() === 'year' ? 'year' : 'number',
         ];
       }
 
@@ -510,10 +508,8 @@ function generateSchema(data: any[]) {
       );
 
       return [
-        metric, 
-        uniqueValues.size < maxUniqueValuesForCategory
-          ? 'category'
-          : 'string',
+        metric,
+        uniqueValues.size < maxUniqueValuesForCategory ? 'category' : 'string',
       ];
     })
   );
@@ -559,6 +555,17 @@ export const cellTypeMap = {
     filter: StringFilter,
     format: (d: string) => d,
     shortFormat: (d: string) => d,
+    sortValueType: 'string',
+  },
+  object: {
+    cell: StringCell,
+    filter: StringFilter,
+    format: (d: string) => JSON.stringify(d),
+    shortFormat: (d: string) => JSON.stringify(d),
+    parseValueFunction: (d: any[]) =>
+      // prettier-ignore
+      typeof d === "object" ? JSON.stringify(d, undefined, 2) :
+      typeof d === 'string' ? d : '',
     sortValueType: 'string',
   },
   array: {

--- a/src/store.ts
+++ b/src/store.ts
@@ -484,20 +484,30 @@ function generateSchema(data: any[]) {
             : 'short-array',
         ];
       }
-      let type = Number.isFinite(+value) ? 'number' : 'string';
-      if (type === 'string') {
-        const uniqueValues = new Set(data.map(d => d[metric]));
-        const maxUniqueValuesForCategory = Math.min(
-          Math.floor(data.length / 3),
-          20
-        );
-        if (uniqueValues.size < maxUniqueValuesForCategory) type = 'category';
+      const isFiniteNumber = Number.isFinite(+value);
+      if (isFiniteNumber) {
+        return [
+          metric,
+          metric.toLowerCase().trim() === 'year'
+            ? 'year'
+            : 'number',
+        ];
       }
 
-      if (type === 'number' && metric.toLowerCase().trim() === 'year')
-        return [metric, 'year'];
+      // If there are few unique values for the metric,
+      // consider the metric as a category
+      const uniqueValues = new Set(data.map(d => d[metric]));
+      const maxUniqueValuesForCategory = Math.min(
+        Math.floor(data.length / 3),
+        20
+      );
 
-      return [metric, type];
+      return [
+        metric, 
+        uniqueValues.size < maxUniqueValuesForCategory
+          ? 'category'
+          : 'string',
+      ];
     })
   );
   return schema;


### PR DESCRIPTION
When determining diffs, old and new values for a given row of data are compared using the equality operator. This does not work for objects, which would need comparison of the entire object. Further, the store currently assumes objects to be strings when generating schema.

A possible solution would be to recognise object values during schema generation, and performing a deep comparison for such values when determining diffs.

This PR consists of two parts:

**refactor(store): separate number and string-related schema generation**

- Move number-related metric type identification into one contiguous
  block; if the value is a finite number, return early with either a
  year or number type, depending on the name of the metric
- Similarly, move the identification of string-related types into its
  own block at the end; give the type as either a string or category
  depending on the number of unique values for the metric

**feat(store): enable deep comparison of objects in diffs**

- Identify objects during schema generation
- Use lodash's `isEqual()` to compare values if cell type is object