### PR TITLE
Use full npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ It will...
 Install using npm or yarn:
 
 ```bash
-yarn add flat-ui
+yarn add @githubocto/flat-ui
 ```
 
 Basic usage:
 
 ```javascript
-import Grid from 'flat-ui';
+import Grid from '@githubocto/flat-ui';
 
 const MyComponent = () => {
   const data = [{ column1: 123 }, { column1: 234 }];


### PR DESCRIPTION
## What's done

- Updated README to use full package name `@githubocto/flat-ui`
- Otherwise it was installing `flat-ui` that's a completely different package