### PR TITLE
Import destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add @githubocto/flat-ui
 Basic usage:
 
 ```javascript
-import Grid from '@githubocto/flat-ui';
+import { Grid } from '@githubocto/flat-ui';
 
 const MyComponent = () => {
   const data = [{ column1: 123 }, { column1: 234 }];


### PR DESCRIPTION
## What's done

- README updated for importing Grid component
- Requires destructuring before usage, otherwise it can't resolve the component