### PR TITLE
fix(csv): ensure proper formatting of values

### DIFF
--- a/src/components/grid.tsx
+++ b/src/components/grid.tsx
@@ -271,7 +271,26 @@ export function Grid(props: GridProps) {
       filteredData
         .map(d =>
           columnNames
-            .map(columnName => d['__rawData__'][columnName] || d[columnName])
+            .map(columnName => {
+              // @ts-ignore
+              const cellType = cellTypes[columnName]
+              // @ts-ignore
+              const data = d['__rawData__'][columnName] || d[columnName]
+              let formattedData = typeof data === 'object' 
+                ? JSON.stringify(data) 
+                : data
+              if (
+                typeof formattedData === 'string' &&
+                (
+                  formattedData.includes('"') || 
+                  formattedData.includes(',') || 
+                  formattedData.includes('\n')
+                )
+              ) {
+                formattedData = `"${formattedData.replace(/"/g, '""')}"`
+              }
+              return formattedData
+            })
             .join(',')
         )
         .join('\n'),


### PR DESCRIPTION
Ensure that downloaded CSVs are properly formatted

- `JSON.stringify()` object-type values

- Ensure proper quotation of values per [RFC4180 Section 2](https://datatracker.ietf.org/doc/html/rfc4180#section-2), clauses 6 and 7; if a
  value contains `"` or `,` or a newline, enclose in double-quotes
  and take care to escape pre-existing `"` as `""`