### PR TITLE
Fix schema `color` bug

### DIFF
--- a/src/components/filters/category.tsx
+++ b/src/components/filters/category.tsx
@@ -87,7 +87,6 @@ export function CategoryFilter(props: CategoryFilterProps) {
                   const isFilteredOut =
                     inputValue && !matchSorter([value], inputValue).length;
                   if (isFilteredOut) return null;
-                  console.log({ color });
 
                   return (
                     <li

--- a/src/store.ts
+++ b/src/store.ts
@@ -577,7 +577,9 @@ function generateSchema(data: any[]) {
         try {
           if (typeof value === 'string') {
             const color = rgb(value);
-            return !!color;
+            const { r, g, b} = color
+            
+            return r && g && b;
           }
           return false;
         } catch (e) {


### PR DESCRIPTION
The logic for inferring colors in the schema was setting any string field as a color. This is because the `d3` color